### PR TITLE
fix(contributing): remove redundancy in example

### DIFF
--- a/Writerside/topics/Contributing.md
+++ b/Writerside/topics/Contributing.md
@@ -35,8 +35,8 @@ just looking to the commit message.
 
 To write conventional commits, follow these best practices:
 
-- Use a clear and descriptive <description> in the imperative mood.
-  - Example: `feat(users): add user registration feature`
+Use a clear and descriptive <description> in the imperative mood.
+  - Example: `feat(users): add registration feature`
 
 - Consider specifying a `<scope>` to provide context for larger 
 codebases or projects with multiple components.


### PR DESCRIPTION
Removes the redundancy in the `scope` context example.